### PR TITLE
Fix undefined QLabel error

### DIFF
--- a/auto_test_tool/requirements.txt
+++ b/auto_test_tool/requirements.txt
@@ -1,2 +1,2 @@
 PyQt5==5.15.9
-paramiko==3.4.0
+paramiko>=3.4.1

--- a/auto_test_tool/ui/config_window.py
+++ b/auto_test_tool/ui/config_window.py
@@ -3,7 +3,7 @@
 
 from PyQt5.QtWidgets import (QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, 
                              QScrollArea, QPushButton, QMessageBox, QFileDialog,
-                             QApplication, QTabWidget, QTextEdit)
+                             QApplication, QTabWidget, QTextEdit, QLabel)
 from PyQt5.QtCore import Qt, pyqtSignal
 from typing import Dict, List, Tuple
 from .widgets import (FileConfigListWidget, GroupBoxWidget, LabeledLineEdit, 


### PR DESCRIPTION
Fixes `QLabel` not defined error and updates `paramiko` to resolve a `TripleDES` deprecation warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f071df3-de62-4235-9ccf-e810d0212563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f071df3-de62-4235-9ccf-e810d0212563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

